### PR TITLE
Add BORG_RSH entry under an environment option

### DIFF
--- a/nixos/modules/services/backup/borgbackup.xml
+++ b/nixos/modules/services/backup/borgbackup.xml
@@ -179,7 +179,7 @@ sudo borg init --encryption=repokey-blake2  \
           mode = "repokey-blake2";
           passCommand = "cat /run/keys/borgbackup_passphrase";
         };
-        BORG_RSH = "ssh -i /run/keys/id_ed25519_borgbase";
+        environment = { BORG_RSH = "ssh -i /run/keys/id_ed25519_borgbase"; };
         compression = "auto,lzma";
         startAt = "daily";
     };


### PR DESCRIPTION
##### Fix a snippet typo in borgbackup entry of manual

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
